### PR TITLE
Enable maven support in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "maven": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
Maven is currently opt-in, so you need to add a renovate config with maven explicitly enabled to trigger the bot.